### PR TITLE
Example of another tool that generates the schema

### DIFF
--- a/helm/zot/values.schema.json
+++ b/helm/zot/values.schema.json
@@ -1,412 +1,862 @@
 {
-    "$schema": "http://json-schema.org/schema#",
-    "type": "object",
-    "properties": {
-        "configFiles": {
-            "type": "object",
-            "properties": {
-                "config.json": {
-                    "type": "string"
-                }
-            }
-        },
-        "env": {
-            "type": "null"
-        },
-        "externalSecrets": {
-            "type": "array"
-        },
-        "extraVolumeMounts": {
-            "type": "array"
-        },
-        "extraVolumes": {
-            "type": "array"
-        },
-        "giantswarm": {
-            "type": "object",
-            "properties": {
-                "images": {
-                    "type": "object",
-                    "properties": {
-                        "alpine": {
-                            "type": "object",
-                            "properties": {
-                                "image": {
-                                    "type": "string"
-                                },
-                                "tag": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "registry": {
-                            "type": "string"
-                        },
-                        "zot": {
-                            "type": "object",
-                            "properties": {
-                                "image": {
-                                    "type": "string"
-                                },
-                                "tag": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "verticalPodAutoscaler": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "force": {
-                            "type": "boolean"
-                        }
-                    }
-                }
-            }
-        },
-        "global": {
-            "type": "object",
-            "properties": {
-                "podSecurityStandards": {
-                    "type": "object",
-                    "properties": {
-                        "enforced": {
-                            "type": "boolean"
-                        }
-                    }
-                }
-            }
-        },
-        "httpGet": {
-            "type": "object",
-            "properties": {
-                "scheme": {
-                    "type": "string"
-                }
-            }
-        },
-        "image": {
-            "type": "object",
-            "properties": {
-                "pullPolicy": {
-                    "type": "string"
-                },
-                "repository": {
-                    "type": "string"
+  "additionalProperties": false,
+  "properties": {
+    "configFiles": {
+      "additionalProperties": false,
+      "properties": {
+        "config.json": {
+          "default": "{\n  \"storage\": { \"rootDirectory\": \"/var/lib/registry\" },\n  \"http\": { \"address\": \"0.0.0.0\", \"port\": \"5000\" },\n  \"log\": { \"level\": \"debug\" }\n}",
+          "title": "config.json",
+          "type": "string"
+        }
+      },
+      "description": "If mountConfig is true the chart creates the '$CHART_RELEASE-config', if it\ndoes not exist the user is in charge of managing it (as this file includes a\nsample file you have to add it empty to handle it externally) ... note that\nthe service does not reload the configFiles once mounted, so you need to\ndelete the pods to create new ones to use the new values.",
+      "title": "configFiles",
+      "type": "object",
+      "required": [
+        "config.json"
+      ]
+    },
+    "env": {
+      "default": "",
+      "description": "List of environment variables to set on the container",
+      "title": "env",
+      "type": "null"
+    },
+    "externalSecrets": {
+      "items": {},
+      "description": "externalSecrets allows to mount external (meaning not managed by this chart)\nKubernetes secrets within the Zot container.\nThe secret is identified by its name (property \"secretName\") and should be\npresent in the same namespace. The property \"mountPath\" specifies the path\nwithin the container filesystem where the secret is mounted.\n#\nBelow is an example:\n#\n externalSecrets:\n - secretName: \"secret1\"\n   mountPath: \"/secrets/s1\"\n - secretName: \"secret2\"\n   mountPath: \"/secrets/s2\"",
+      "title": "externalSecrets",
+      "type": "array"
+    },
+    "extraVolumeMounts": {
+      "items": {},
+      "description": "Extra Volume Mounts",
+      "title": "extraVolumeMounts",
+      "type": "array"
+    },
+    "extraVolumes": {
+      "items": {},
+      "description": "Extra Volumes",
+      "title": "extraVolumes",
+      "type": "array"
+    },
+    "giantswarm": {
+      "additionalProperties": false,
+      "properties": {
+        "images": {
+          "additionalProperties": false,
+          "properties": {
+            "alpine": {
+              "additionalProperties": false,
+              "properties": {
+                "image": {
+                  "default": "giantswarm/alpine",
+                  "title": "image",
+                  "type": "string"
                 },
                 "tag": {
-                    "type": "string"
+                  "default": "3.18",
+                  "title": "tag",
+                  "type": "string"
                 }
-            }
-        },
-        "ingress": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object"
+              },
+              "title": "alpine",
+              "type": "object",
+              "required": [
+                "image",
+                "tag"
+              ]
+            },
+            "registry": {
+              "default": "gsoci.azurecr.io",
+              "title": "registry",
+              "type": "string"
+            },
+            "zot": {
+              "additionalProperties": false,
+              "properties": {
+                "image": {
+                  "default": "giantswarm/zot-linux-amd64",
+                  "title": "image",
+                  "type": "string"
                 },
-                "className": {
-                    "type": "string"
-                },
-                "enabled": {
-                    "type": "boolean"
-                },
-                "hosts": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "host": {
-                                "type": "string"
-                            },
-                            "paths": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "path": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "pathtype": {
-                    "type": "string"
-                },
-                "tls": {
-                    "type": "array"
+                "tag": {
+                  "default": "",
+                  "description": "defaults to appVersion in chart.yaml",
+                  "title": "tag",
+                  "type": "string"
                 }
+              },
+              "title": "zot",
+              "type": "object",
+              "required": [
+                "image",
+                "tag"
+              ]
             }
+          },
+          "title": "images",
+          "type": "object",
+          "required": [
+            "registry",
+            "zot",
+            "alpine"
+          ]
         },
-        "mountConfig": {
-            "type": "boolean"
-        },
-        "mountSecret": {
-            "type": "boolean"
-        },
-        "persistence": {
-            "type": "boolean"
-        },
-        "podAnnotations": {
-            "type": "object"
-        },
-        "podSecurityContext": {
-            "type": "object",
-            "properties": {
-                "fsGroup": {
-                    "type": "integer"
-                },
-                "fsGroupChangePolicy": {
-                    "type": "string"
-                },
-                "runAsGroup": {
-                    "type": "integer"
-                },
-                "runAsNonRoot": {
-                    "type": "boolean"
-                },
-                "runAsUser": {
-                    "type": "integer"
-                },
-                "seccompProfile": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                }
+        "verticalPodAutoscaler": {
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "default": "true",
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "force": {
+              "default": "false",
+              "description": "Enables bypassing \"autoscaling.k8s.io/v1\" check; use with care",
+              "title": "force",
+              "type": "boolean"
             }
-        },
-        "pvc": {
-            "type": "object",
-            "properties": {
-                "accessMode": {
-                    "type": "string"
-                },
-                "create": {
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "null"
-                },
-                "policyException": {
-                    "type": "object",
-                    "properties": {
-                        "enforce": {
-                            "type": "boolean"
-                        },
-                        "namespace": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "storage": {
-                    "type": "string"
-                },
-                "storageClassName": {
-                    "type": "string"
-                }
-            }
-        },
-        "replicaCount": {
-            "type": "integer"
-        },
-        "resources": {
-            "type": "object",
-            "properties": {
-                "limits": {
-                    "type": "object",
-                    "properties": {
-                        "cpu": {
-                            "type": "string"
-                        },
-                        "memory": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "requests": {
-                    "type": "object",
-                    "properties": {
-                        "cpu": {
-                            "type": "string"
-                        },
-                        "memory": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "secretFiles": {
-            "type": "object",
-            "properties": {
-                "htpasswd": {
-                    "type": "string"
-                }
-            }
-        },
-        "securityContext": {
-            "type": "object",
-            "properties": {
-                "allowPrivilegeEscalation": {
-                    "type": "boolean"
-                },
-                "capabilities": {
-                    "type": "object",
-                    "properties": {
-                        "drop": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "readOnlyRootFilesystem": {
-                    "type": "boolean"
-                },
-                "runAsGroup": {
-                    "type": "integer"
-                },
-                "runAsNonRoot": {
-                    "type": "boolean"
-                },
-                "runAsUser": {
-                    "type": "integer"
-                },
-                "seccompProfile": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "service": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object"
-                },
-                "clusterIP": {
-                    "type": "null"
-                },
-                "nodePort": {
-                    "type": "null"
-                },
-                "port": {
-                    "type": "integer"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "serviceAccount": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object"
-                },
-                "create": {
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
-        },
-        "serviceMonitor": {
-            "type": "object",
-            "properties": {
-                "additionalLabels": {
-                    "type": "object"
-                },
-                "basicAuth": {
-                    "type": "object"
-                },
-                "enabled": {
-                    "type": "boolean"
-                },
-                "honorLabels": {
-                    "type": "boolean"
-                },
-                "interval": {
-                    "type": "string"
-                },
-                "metricRelabelings": {
-                    "type": "array"
-                },
-                "namespace": {
-                    "type": "string"
-                },
-                "relabelings": {
-                    "type": "array"
-                },
-                "scrapeTimeout": {
-                    "type": "string"
-                }
-            }
-        },
-        "startupProbe": {
-            "type": "object",
-            "properties": {
-                "failureThreshold": {
-                    "type": "integer"
-                },
-                "initialDelaySeconds": {
-                    "type": "integer"
-                },
-                "periodSeconds": {
-                    "type": "integer"
-                }
-            }
-        },
-        "strategy": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "testPodResources": {
-            "type": "object",
-            "properties": {
-                "limits": {
-                    "type": "object",
-                    "properties": {
-                        "cpu": {
-                            "type": "string"
-                        },
-                        "memory": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "requests": {
-                    "type": "object",
-                    "properties": {
-                        "cpu": {
-                            "type": "string"
-                        },
-                        "memory": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
+          },
+          "title": "verticalPodAutoscaler",
+          "type": "object",
+          "required": [
+            "enabled",
+            "force"
+          ]
         }
+      },
+      "title": "giantswarm",
+      "type": "object",
+      "required": [
+        "images",
+        "verticalPodAutoscaler"
+      ]
+    },
+    "global": {
+      "additionalProperties": false,
+      "properties": {
+        "podSecurityStandards": {
+          "additionalProperties": false,
+          "properties": {
+            "enforced": {
+              "default": "false",
+              "title": "enforced",
+              "type": "boolean"
+            }
+          },
+          "title": "podSecurityStandards",
+          "type": "object",
+          "required": [
+            "enforced"
+          ]
+        }
+      },
+      "title": "global",
+      "type": "object",
+      "required": [
+        "podSecurityStandards"
+      ]
+    },
+    "httpGet": {
+      "additionalProperties": false,
+      "properties": {
+        "scheme": {
+          "default": "HTTP",
+          "title": "scheme",
+          "type": "string"
+        }
+      },
+      "description": "By default, Kubernetes HTTP probes use HTTP 'scheme'. So if TLS is enabled\nin configuration, to prevent failures, the scheme must be set to 'HTTPS'.",
+      "title": "httpGet",
+      "type": "object",
+      "required": [
+        "scheme"
+      ]
+    },
+    "image": {
+      "additionalProperties": false,
+      "properties": {
+        "pullPolicy": {
+          "default": "IfNotPresent",
+          "title": "pullPolicy",
+          "type": "string"
+        },
+        "repository": {
+          "default": "gsoci.azurecr.io/giantswarm/zot-linux-amd64",
+          "title": "repository",
+          "type": "string"
+        },
+        "tag": {
+          "default": "v2.0.3",
+          "description": "Overrides the image tag whose default is the chart appVersion.",
+          "title": "tag",
+          "type": "string"
+        }
+      },
+      "title": "image",
+      "type": "object",
+      "required": [
+        "repository",
+        "pullPolicy",
+        "tag"
+      ]
+    },
+    "ingress": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "additionalProperties": false,
+          "title": "annotations",
+          "type": "object"
+        },
+        "className": {
+          "default": "nginx",
+          "description": "kubernetes.io/ingress.class: nginx\nkubernetes.io/tls-acme: \"true\"\nIf using nginx, disable body limits and increase read and write timeouts\nnginx.ingress.kubernetes.io/proxy-body-size: \"0\"\nnginx.ingress.kubernetes.io/proxy-read-timeout: \"600\"\nnginx.ingress.kubernetes.io/proxy-send-timeout: \"600\"",
+          "title": "className",
+          "type": "string"
+        },
+        "enabled": {
+          "default": "false",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "hosts": {
+          "items": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "host": {
+                    "default": "chart-example.local",
+                    "title": "host",
+                    "type": "string"
+                  },
+                  "paths": {
+                    "items": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "path": {
+                              "default": "/",
+                              "title": "path",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ]
+                        }
+                      ]
+                    },
+                    "title": "paths",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "host",
+                  "paths"
+                ]
+              }
+            ]
+          },
+          "title": "hosts",
+          "type": "array"
+        },
+        "pathtype": {
+          "default": "ImplementationSpecific",
+          "title": "pathtype",
+          "type": "string"
+        },
+        "tls": {
+          "items": {},
+          "title": "tls",
+          "type": "array"
+        }
+      },
+      "description": "Enabling this will publicly expose your zot server\nOnly enable this if you have security enabled on your cluster",
+      "title": "ingress",
+      "type": "object",
+      "required": [
+        "enabled",
+        "annotations",
+        "className",
+        "pathtype",
+        "hosts",
+        "tls"
+      ]
+    },
+    "mountConfig": {
+      "default": "true",
+      "description": "If mountConfig is true the configMap named $CHART_RELEASE-config is mounted\non the pod's '/etc/zot' directory",
+      "title": "mountConfig",
+      "type": "boolean"
+    },
+    "mountSecret": {
+      "default": "false",
+      "description": "If mountSecret is true, the Secret named $CHART_RELEASE-secret is mounted on\nthe pod's '/secret' directory (it is used to keep files with passwords, like\na `htpasswd` file)",
+      "title": "mountSecret",
+      "type": "boolean"
+    },
+    "persistence": {
+      "default": "false",
+      "description": "If persistence is 'true' the service uses a persistentVolumeClaim to mount a\nvolume for zot on '/var/lib/registry'; by default the pvc used is named\n'$CHART_RELEASE-pvc', but the name can be changed below",
+      "title": "persistence",
+      "type": "boolean"
+    },
+    "podAnnotations": {
+      "additionalProperties": false,
+      "title": "podAnnotations",
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "additionalProperties": false,
+      "properties": {
+        "fsGroup": {
+          "default": "1000",
+          "title": "fsGroup",
+          "type": "integer"
+        },
+        "fsGroupChangePolicy": {
+          "default": "OnRootMismatch",
+          "title": "fsGroupChangePolicy",
+          "type": "string"
+        },
+        "runAsGroup": {
+          "default": "1000",
+          "title": "runAsGroup",
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "default": "true",
+          "title": "runAsNonRoot",
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "default": "1000",
+          "title": "runAsUser",
+          "type": "integer"
+        },
+        "seccompProfile": {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "default": "RuntimeDefault",
+              "title": "type",
+              "type": "string"
+            }
+          },
+          "title": "seccompProfile",
+          "type": "object",
+          "required": [
+            "type"
+          ]
+        }
+      },
+      "title": "podSecurityContext",
+      "type": "object",
+      "required": [
+        "runAsNonRoot",
+        "runAsUser",
+        "runAsGroup",
+        "fsGroup",
+        "fsGroupChangePolicy",
+        "seccompProfile"
+      ]
+    },
+    "pvc": {
+      "additionalProperties": false,
+      "properties": {
+        "accessMode": {
+          "default": "ReadWriteOnce",
+          "description": "Volume access mode, if using more than one replica we need",
+          "title": "accessMode",
+          "type": "string"
+        },
+        "create": {
+          "default": "false",
+          "description": "Make the chart create the PVC, this option is used with storageClasses that\ncan create volumes dynamically, if that is not the case is better to do it\nmanually and set create to false",
+          "title": "create",
+          "type": "boolean"
+        },
+        "name": {
+          "default": "",
+          "description": "Name of the PVC to use or create if persistence is enabled, if not set the\nvalue '$CHART_RELEASE-pvc' is used",
+          "title": "name",
+          "type": "null"
+        },
+        "policyException": {
+          "additionalProperties": false,
+          "properties": {
+            "enforce": {
+              "default": "false",
+              "title": "enforce",
+              "type": "boolean"
+            },
+            "namespace": {
+              "default": "policy-exceptions",
+              "title": "namespace",
+              "type": "string"
+            }
+          },
+          "title": "policyException",
+          "type": "object",
+          "required": [
+            "enforce",
+            "namespace"
+          ]
+        },
+        "storage": {
+          "default": "8Gi",
+          "description": "Size of the volume requested",
+          "title": "storage",
+          "type": "string"
+        },
+        "storageClassName": {
+          "default": "",
+          "description": "Name of the storage class to use if it is different than the default one",
+          "title": "storageClassName",
+          "type": "string"
+        }
+      },
+      "description": "PVC data, only used if persistence is 'true'",
+      "title": "pvc",
+      "type": "object",
+      "required": [
+        "create",
+        "name",
+        "accessMode",
+        "storage",
+        "storageClassName",
+        "policyException"
+      ]
+    },
+    "replicaCount": {
+      "default": "1",
+      "description": "Default values for zot.\nThis is a YAML-formatted file.\nDeclare variables to be passed into your templates.",
+      "title": "replicaCount",
+      "type": "integer"
+    },
+    "resources": {
+      "additionalProperties": false,
+      "properties": {
+        "limits": {
+          "additionalProperties": false,
+          "properties": {
+            "cpu": {
+              "default": "1000m",
+              "title": "cpu",
+              "type": "string"
+            },
+            "memory": {
+              "default": "1024Mi",
+              "title": "memory",
+              "type": "string"
+            }
+          },
+          "title": "limits",
+          "type": "object",
+          "required": [
+            "cpu",
+            "memory"
+          ]
+        },
+        "requests": {
+          "additionalProperties": false,
+          "properties": {
+            "cpu": {
+              "default": "500m",
+              "title": "cpu",
+              "type": "string"
+            },
+            "memory": {
+              "default": "512Mi",
+              "title": "memory",
+              "type": "string"
+            }
+          },
+          "title": "requests",
+          "type": "object",
+          "required": [
+            "cpu",
+            "memory"
+          ]
+        }
+      },
+      "title": "resources",
+      "type": "object",
+      "required": [
+        "requests",
+        "limits"
+      ]
+    },
+    "secretFiles": {
+      "additionalProperties": false,
+      "properties": {
+        "htpasswd": {
+          "default": "admin:$2y$05$vmiurPmJvHylk78HHFWuruFFVePlit9rZWGA/FbZfTEmNRneGJtha\nuser:$2y$05$L86zqQDfH5y445dcMlwu6uHv.oXFgT6AiJCwpv3ehr7idc0rI3S2G",
+          "description": "Example htpasswd with 'admin:admin' \u0026 'user:user' user:pass pairs",
+          "title": "htpasswd",
+          "type": "string"
+        }
+      },
+      "description": "If secretFiles does not exist the user is in charge of managing it, again, if\nyou want to manage it the value has to be added empty to avoid using this one",
+      "title": "secretFiles",
+      "type": "object",
+      "required": [
+        "htpasswd"
+      ]
+    },
+    "securityContext": {
+      "additionalProperties": false,
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "default": "false",
+          "title": "allowPrivilegeEscalation",
+          "type": "boolean"
+        },
+        "capabilities": {
+          "additionalProperties": false,
+          "properties": {
+            "drop": {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "title": "drop",
+              "type": "array"
+            }
+          },
+          "title": "capabilities",
+          "type": "object",
+          "required": [
+            "drop"
+          ]
+        },
+        "readOnlyRootFilesystem": {
+          "default": "true",
+          "title": "readOnlyRootFilesystem",
+          "type": "boolean"
+        },
+        "runAsGroup": {
+          "default": "1000",
+          "title": "runAsGroup",
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "default": "true",
+          "title": "runAsNonRoot",
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "default": "1000",
+          "title": "runAsUser",
+          "type": "integer"
+        },
+        "seccompProfile": {
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "default": "RuntimeDefault",
+              "title": "type",
+              "type": "string"
+            }
+          },
+          "title": "seccompProfile",
+          "type": "object",
+          "required": [
+            "type"
+          ]
+        }
+      },
+      "title": "securityContext",
+      "type": "object",
+      "required": [
+        "allowPrivilegeEscalation",
+        "capabilities",
+        "readOnlyRootFilesystem",
+        "runAsNonRoot",
+        "runAsUser",
+        "runAsGroup",
+        "seccompProfile"
+      ]
+    },
+    "service": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "additionalProperties": false,
+          "description": "Annotations to add to the service",
+          "title": "annotations",
+          "type": "object"
+        },
+        "clusterIP": {
+          "default": "null",
+          "description": "Set to a static IP if a static IP is desired, only works when\ntype: ClusterIP\ntype: [string, null]",
+          "title": "clusterIP",
+          "type": "null"
+        },
+        "nodePort": {
+          "default": "null",
+          "title": "nodePort",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "port": {
+          "default": "5000",
+          "title": "port",
+          "type": "integer"
+        },
+        "type": {
+          "default": "NodePort",
+          "title": "type",
+          "type": "string"
+        }
+      },
+      "title": "service",
+      "type": "object",
+      "required": [
+        "type",
+        "port",
+        "annotations",
+        "clusterIP"
+      ]
+    },
+    "serviceAccount": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "additionalProperties": false,
+          "description": "Annotations to add to the service account",
+          "title": "annotations",
+          "type": "object"
+        },
+        "create": {
+          "default": "true",
+          "description": "Specifies whether a service account should be created",
+          "title": "create",
+          "type": "boolean"
+        },
+        "name": {
+          "default": "",
+          "description": "The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template",
+          "title": "name",
+          "type": "string"
+        }
+      },
+      "title": "serviceAccount",
+      "type": "object",
+      "required": [
+        "create",
+        "annotations",
+        "name"
+      ]
+    },
+    "serviceMonitor": {
+      "additionalProperties": false,
+      "properties": {
+        "additionalLabels": {
+          "additionalProperties": false,
+          "description": "Additional labels",
+          "title": "additionalLabels",
+          "type": "object"
+        },
+        "basicAuth": {
+          "additionalProperties": false,
+          "description": "- sourceLabels: [__meta_kubernetes_pod_node_name]\n  separator: ;\n  regex: ^(.*)$\n  targetLabel: nodename\n  replacement: $1\n  action: replace\n#",
+          "title": "basicAuth",
+          "type": "object"
+        },
+        "enabled": {
+          "default": "false",
+          "description": "Specifies whether to create a ServiceMonitor resource for collecting Prometheus metrics",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "honorLabels": {
+          "default": "false",
+          "description": "Let prometheus add an exported_ prefix to conflicting labels",
+          "title": "honorLabels",
+          "type": "boolean"
+        },
+        "interval": {
+          "default": "30s",
+          "description": " Interval to scrape metrics",
+          "title": "interval",
+          "type": "string"
+        },
+        "metricRelabelings": {
+          "items": {},
+          "description": "Metric relabel configs to apply to samples before ingestion. [Metric Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs)",
+          "title": "metricRelabelings",
+          "type": "array"
+        },
+        "namespace": {
+          "default": "",
+          "description": "namespace where you want to install ServiceMonitors",
+          "title": "namespace",
+          "type": "string"
+        },
+        "relabelings": {
+          "items": {},
+          "description": "- action: replace\n  regex: (.*)\n  replacement: $1\n  sourceLabels:\n  - exported_namespace\n  targetLabel: namespace\nRelabel configs to apply to samples before ingestion. [Relabeling](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)",
+          "title": "relabelings",
+          "type": "array"
+        },
+        "scrapeTimeout": {
+          "default": "25s",
+          "description": "Timeout if metrics can't be retrieved in given time interval",
+          "title": "scrapeTimeout",
+          "type": "string"
+        }
+      },
+      "title": "serviceMonitor",
+      "type": "object",
+      "required": [
+        "enabled",
+        "namespace",
+        "additionalLabels",
+        "interval",
+        "scrapeTimeout",
+        "honorLabels",
+        "metricRelabelings",
+        "relabelings",
+        "basicAuth"
+      ]
+    },
+    "startupProbe": {
+      "additionalProperties": false,
+      "properties": {
+        "failureThreshold": {
+          "default": "3",
+          "title": "failureThreshold",
+          "type": "integer"
+        },
+        "initialDelaySeconds": {
+          "default": "5",
+          "title": "initialDelaySeconds",
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "default": "10",
+          "title": "periodSeconds",
+          "type": "integer"
+        }
+      },
+      "description": "By default, Kubernetes considers a Pod healthy if the liveness probe returns\nsuccessfully. However, sometimes applications need additional startup time on\ntheir first initialization. By defining a startupProbe, we can allow the\napplication to take extra time for initialization without compromising fast\nresponse to deadlocks.",
+      "title": "startupProbe",
+      "type": "object",
+      "required": [
+        "initialDelaySeconds",
+        "periodSeconds",
+        "failureThreshold"
+      ]
+    },
+    "strategy": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "default": "RollingUpdate",
+          "title": "type",
+          "type": "string"
+        }
+      },
+      "description": "Deployment strategy type",
+      "title": "strategy",
+      "type": "object",
+      "required": [
+        "type"
+      ]
+    },
+    "testPodResources": {
+      "additionalProperties": false,
+      "properties": {
+        "limits": {
+          "additionalProperties": false,
+          "properties": {
+            "cpu": {
+              "default": "100m",
+              "title": "cpu",
+              "type": "string"
+            },
+            "memory": {
+              "default": "64Mi",
+              "title": "memory",
+              "type": "string"
+            }
+          },
+          "title": "limits",
+          "type": "object",
+          "required": [
+            "cpu",
+            "memory"
+          ]
+        },
+        "requests": {
+          "additionalProperties": false,
+          "properties": {
+            "cpu": {
+              "default": "100m",
+              "title": "cpu",
+              "type": "string"
+            },
+            "memory": {
+              "default": "64Mi",
+              "title": "memory",
+              "type": "string"
+            }
+          },
+          "title": "requests",
+          "type": "object",
+          "required": [
+            "cpu",
+            "memory"
+          ]
+        }
+      },
+      "title": "testPodResources",
+      "type": "object",
+      "required": [
+        "requests",
+        "limits"
+      ]
     }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "giantswarm",
+    "resources",
+    "testPodResources",
+    "podSecurityContext",
+    "securityContext",
+    "replicaCount",
+    "image",
+    "serviceAccount",
+    "service",
+    "ingress",
+    "httpGet",
+    "startupProbe",
+    "mountConfig",
+    "configFiles",
+    "externalSecrets",
+    "mountSecret",
+    "secretFiles",
+    "persistence",
+    "pvc",
+    "env",
+    "extraVolumeMounts",
+    "extraVolumes",
+    "strategy",
+    "podAnnotations",
+    "serviceMonitor",
+    "global"
+  ]
 }

--- a/helm/zot/values.schema.json
+++ b/helm/zot/values.schema.json
@@ -19,7 +19,7 @@
     },
     "env": {
       "default": "",
-      "description": "List of environment variables to set on the container",
+      "description": "@scheme\nrequired: false\n@scheme\nList of environment variables to set on the container",
       "title": "env",
       "type": "null"
     },
@@ -383,7 +383,7 @@
         },
         "name": {
           "default": "",
-          "description": "Name of the PVC to use or create if persistence is enabled, if not set the\nvalue '$CHART_RELEASE-pvc' is used",
+          "description": "@scheme\nrequired: false\n@scheme\nName of the PVC to use or create if persistence is enabled, if not set the\nvalue '$CHART_RELEASE-pvc' is used",
           "title": "name",
           "type": "null"
         },
@@ -597,9 +597,12 @@
         },
         "clusterIP": {
           "default": "null",
-          "description": "Set to a static IP if a static IP is desired, only works when\ntype: ClusterIP\ntype: [string, null]",
+          "description": "Set to a static IP if a static IP is desired, only works when",
           "title": "clusterIP",
-          "type": "null"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "nodePort": {
           "default": "null",
@@ -625,8 +628,7 @@
       "required": [
         "type",
         "port",
-        "annotations",
-        "clusterIP"
+        "annotations"
       ]
     },
     "serviceAccount": {

--- a/helm/zot/values.schema.json
+++ b/helm/zot/values.schema.json
@@ -19,9 +19,12 @@
     },
     "env": {
       "default": "",
-      "description": "@scheme\nrequired: false\n@scheme\nList of environment variables to set on the container",
+      "description": "List of environment variables to set on the container",
       "title": "env",
-      "type": "null"
+      "type": [
+        "array",
+        "null"
+      ]
     },
     "externalSecrets": {
       "items": {},
@@ -383,9 +386,8 @@
         },
         "name": {
           "default": "",
-          "description": "@scheme\nrequired: false\n@scheme\nName of the PVC to use or create if persistence is enabled, if not set the\nvalue '$CHART_RELEASE-pvc' is used",
-          "title": "name",
-          "type": "null"
+          "description": "Name of the PVC to use or create if persistence is enabled, if not set the\nvalue '$CHART_RELEASE-pvc' is used",
+          "title": "name"
         },
         "policyException": {
           "additionalProperties": false,
@@ -426,7 +428,6 @@
       "type": "object",
       "required": [
         "create",
-        "name",
         "accessMode",
         "storage",
         "storageClassName",
@@ -853,7 +854,6 @@
     "secretFiles",
     "persistence",
     "pvc",
-    "env",
     "extraVolumeMounts",
     "extraVolumes",
     "strategy",

--- a/helm/zot/values.yaml
+++ b/helm/zot/values.yaml
@@ -200,9 +200,9 @@ pvc:
   # can create volumes dynamically, if that is not the case is better to do it
   # manually and set create to false
   create: false
-  # @scheme
+  # @schema
   # required: false
-  # @scheme
+  # @schema
   # Name of the PVC to use or create if persistence is enabled, if not set the
   # value '$CHART_RELEASE-pvc' is used
   name:
@@ -215,9 +215,10 @@ pvc:
   policyException:
     enforce: false
     namespace: policy-exceptions
-# @scheme
+# @schema
 # required: false
-# @scheme
+# type: [array, null]
+# @schema
 # List of environment variables to set on the container
 env:
 # - name: "TEST"

--- a/helm/zot/values.yaml
+++ b/helm/zot/values.yaml
@@ -75,9 +75,11 @@ service:
   nodePort: null
   # Annotations to add to the service
   annotations: {}
-  # Set to a static IP if a static IP is desired, only works when
-  # type: ClusterIP
+  # @schema
+  # required: false
   # type: [string, null]
+  # @schema
+  # Set to a static IP if a static IP is desired, only works when
   clusterIP: null
 # Enabling this will publicly expose your zot server
 # Only enable this if you have security enabled on your cluster
@@ -198,6 +200,9 @@ pvc:
   # can create volumes dynamically, if that is not the case is better to do it
   # manually and set create to false
   create: false
+  # @scheme
+  # required: false
+  # @scheme
   # Name of the PVC to use or create if persistence is enabled, if not set the
   # value '$CHART_RELEASE-pvc' is used
   name:
@@ -210,6 +215,9 @@ pvc:
   policyException:
     enforce: false
     namespace: policy-exceptions
+# @scheme
+# required: false
+# @scheme
 # List of environment variables to set on the container
 env:
 # - name: "TEST"

--- a/helm/zot/values.yaml
+++ b/helm/zot/values.yaml
@@ -1,4 +1,3 @@
-# Giant Swarm specific values and defaults
 giantswarm:
   images:
     registry: gsoci.azurecr.io
@@ -50,7 +49,6 @@ securityContext:
   runAsGroup: 1000
   seccompProfile:
     type: RuntimeDefault
-
 # Default values for zot.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
@@ -71,11 +69,15 @@ serviceAccount:
 service:
   type: NodePort
   port: 5000
+  # @schema
+  # type: [integer, null]
+  # @schema
   nodePort: null
   # Annotations to add to the service
   annotations: {}
   # Set to a static IP if a static IP is desired, only works when
   # type: ClusterIP
+  # type: [string, null]
   clusterIP: null
 # Enabling this will publicly expose your zot server
 # Only enable this if you have security enabled on your cluster


### PR DESCRIPTION
This is a pretty new  tool, that I've found out a coupld of weeks ago, and it's doing what I wanted to implement for values schema. It's reading special comments (annotations) in the helm values file and then it generates a schema.

Why do I find it better than the helm-schema plugin, that we use currently?

We have generated the current schema with the plugin, but since the `servce.nodePort` is set to null in the values, the type of this field is null, hence, it's not possible to use any value.

With the helm-schema (tool), it's possible to add an annotation in the values, so it know that it can either be an `integer` of `null`. Please, check the changes.

Also, if it works fine and we want to try it, we could remove schema from the repo, and generate it in CI

