### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/helm/zot/templates/pvc.yaml
+++ b/helm/zot/templates/pvc.yaml
@@ -16,7 +16,7 @@ spec:
 
 {{- if or (.Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException") (eq .Values.pvc.policyException.enforce true) }}
 ---
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: allow-pvc-{{ .Release.Name }}


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.